### PR TITLE
spring-boot-admin-server和spring-boot-admin-client服务

### DIFF
--- a/spring-boot-demo-admin-client/pom.xml
+++ b/spring-boot-demo-admin-client/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-boot-admin.version>2.0.3</spring-boot-admin.version>
+		<spring-boot-admin.version>2.1.0</spring-boot-admin.version>
 	</properties>
 
 	<dependencies>

--- a/spring-boot-demo-admin-server/pom.xml
+++ b/spring-boot-demo-admin-server/pom.xml
@@ -20,7 +20,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-boot-admin.version>2.0.3</spring-boot-admin.version>
+		<spring-boot-admin.version>2.1.0</spring-boot-admin.version>
 	</properties>
 
 	<dependencies>

--- a/spring-boot-demo-admin-server/src/main/resources/application.yml
+++ b/spring-boot-demo-admin-server/src/main/resources/application.yml
@@ -1,7 +1,9 @@
 server:
   port: 8000
+  servlet:
+    context-path: /admin
 spring:
   boot:
     admin:
       # 管控台上下文路径
-      context-path: /admin
+      context-path: /


### PR DESCRIPTION
1、spring-boot-admin版本低于spring-boot版本，导致项目启动失败
2、spring-boot-admin-server配置context-path需修改至server.servlet下，否则启动后无法正常使用