### PR TITLE
bug fix:elasticsearch-rest-high-level-client 模快配置es x-pack security (密码后) 链接失败

### DIFF
--- a/spring-boot-demo-elasticsearch-rest-high-level-client/src/main/java/com/xkcoding/elasticsearch/config/ElasticsearchAutoConfiguration.java
+++ b/spring-boot-demo-elasticsearch-rest-high-level-client/src/main/java/com/xkcoding/elasticsearch/config/ElasticsearchAutoConfiguration.java
@@ -86,8 +86,15 @@ public class ElasticsearchAutoConfiguration {
         ElasticsearchProperties.Account account = elasticsearchProperties.getAccount();
         if (!StringUtils.isEmpty(account.getUsername()) && !StringUtils.isEmpty(account.getUsername())) {
             final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials(account.getUsername(), account.getPassword()));
 
-            credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(account.getUsername(), account.getPassword()));
+            // https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.6/_basic_authentication.html
+            builder.setHttpClientConfigCallback(httpClientBuilder -> {
+                httpClientBuilder.disableAuthCaching();
+                return httpClientBuilder
+                    .setDefaultCredentialsProvider(credentialsProvider);
+            });
         }
         return new RestHighLevelClient(builder);
     }


### PR DESCRIPTION
refrence doc: https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.6/_basic_authentication.html

修复 ： https://github.com/xkcoding/spring-boot-demo/issues/121