### PR TITLE
修复所选空间不在华东时会报错

### DIFF
--- a/demo-upload/src/main/java/com/xkcoding/upload/config/UploadConfig.java
+++ b/demo-upload/src/main/java/com/xkcoding/upload/config/UploadConfig.java
@@ -67,11 +67,11 @@ public class UploadConfig {
     }
 
     /**
-     * 华东机房
+     * 配置机房
      */
     @Bean
     public com.qiniu.storage.Configuration qiniuConfig() {
-        return new com.qiniu.storage.Configuration(Zone.zone0());
+        return new com.qiniu.storage.Configuration(Region.autoRegion());
     }
 
     /**


### PR DESCRIPTION
所选空间不在华东时会报错
Zone已不推荐使用
Region.autoRegion()可自动根据AccessKey和Bucket来判断所在机房，并获取相关的域名

