### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <spring.boot.version>2.1.0.RELEASE</spring.boot.version>
-    <mysql.version>8.0.21</mysql.version>
+    <mysql.version>8.0.28</mysql.version>
     <hutool.version>5.4.5</hutool.version>
     <guava.version>29.0-jre</guava.version>
     <user.agent.version>1.20</user.agent.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 8.0.21
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.21 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS