### PR TITLE
demo-codegen：修复hutool-all-5.4.5里面PageUtil的默认firstPageNo为0导致前端获取第一页数据时设置currentPage=1获取不到第一页数据;修复在db.query时未指定大小写敏感导致Entity的父类customKey默认会将字段名改变成小写导致前端无法获取映射值

### DIFF
--- a/demo-codegen/src/main/java/com/xkcoding/codegen/service/impl/CodeGenServiceImpl.java
+++ b/demo-codegen/src/main/java/com/xkcoding/codegen/service/impl/CodeGenServiceImpl.java
@@ -1,6 +1,7 @@
 package com.xkcoding.codegen.service.impl;
 
 import cn.hutool.core.io.IoUtil;
+import cn.hutool.core.util.PageUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.db.Db;
 import cn.hutool.db.Entity;
@@ -51,8 +52,9 @@ public class CodeGenServiceImpl implements CodeGenService {
     public PageResult<Entity> listTables(TableRequest request) {
         HikariDataSource dataSource = DbUtil.buildFromTableRequest(request);
         Db db = new Db(dataSource);
-
+        db.setCaseInsensitive(false);
         Page page = new Page(request.getCurrentPage(), request.getPageSize());
+        PageUtil.setFirstPageNo(1);
         int start = page.getStartPosition();
         int pageSize = page.getPageSize();
 


### PR DESCRIPTION
fix:修复hutool-all-5.4.5里面PageUtil的默认firstPageNo为0导致前端获取第一页数据时设置currentPage=1获取不到第一页数据;修复在db.query时未指定大小写敏感导致Entity的父类customKey默认会将字段名改变成小写导致前端无法获取映射值

* PR 修复缺陷请先开 `issue` **[报告缺陷](https://github.com/xkcoding/spring-boot-demo/issues/new?template=bug_report.md)**
* PR 提交新特性请先开 `issue` **[报告新特性](https://github.com/xkcoding/spring-boot-demo/issues/new?template=feature_request.md)**
* PR 请提交到 `dev` 开发分支上
* 我们对编码风格有着较为严格的要求，请在阅读代码后模仿类似风格提交
* 欢迎通过 PR 给我们补充案例
